### PR TITLE
Fix: Add compatibility for urllib3 v2.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests-toolbelt>=1.0.0
 requests>=2.31
-urllib3>=1.21.1,<2
+urllib3>=2
 gcloud>=0.18.3
 oauth2client>=4.1.2
 python-jwt>=2.0.1


### PR DESCRIPTION
The [Smarter Kettle HA integration](https://github.com/kbirger/ha-smarter-integration) broke with the most recent HA Core update. The error seems to be because HA dropped [support for urllib3 < 2.0](https://github.com/home-assistant/core/commit/acf31f609a96e935254c810159e44f9a6e6aa45a), which pyrebase-air relied on. This PR passes all the tests (with some deprecation warnings) using urllib3 2.1.0. Note: I have zero experience with Firebase so this code was mostly written by Dingus, but hopefully someone can use it to get the Smarter Kettle HA integration working again.